### PR TITLE
Macos coq8.4 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ theories:
 
 install:
 	$(MAKE) -C theories install
+	$(MAKE) -C theories install-doc
 
 examples: theories
 	$(MAKE) -C examples

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -10,14 +10,21 @@ ARGS :=-R ../theories ExtLib
 coq: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
+OS := $(shell uname)
+ifeq ($(OS),Darwin)
+	SEDFLAGS:=-Ee
+else
+	SEDFLAGS:=-re
+endif
+
 Makefile.coq: Makefile $(VS)
 	coq_makefile $(ARGS) $(VS) \
-          | sed -re 's/-R ([^ ]+) ExtLib/-I \1 -as ExtLib/g' \
+          | sed $(SEDFLAGS) 's/-R ([^ ]+) ExtLib/-I \1 -as ExtLib/g' \
           > Makefile.coq
 
 Makefile.test.coq: Makefile $(TVS)
 	coq_makefile $(ARGS) $(TVS) \
-          | sed -re 's/-R ([^ ]+) ExtLib/-I \1 -as ExtLib/g' \
+          | sed $(SEDFLAGS) 's/-R ([^ ]+) ExtLib/-I \1 -as ExtLib/g' \
           > Makefile.coq
 
 test: coq Makefile.test.coq

--- a/examples/WithDemo.v
+++ b/examples/WithDemo.v
@@ -1,4 +1,4 @@
-Require Import List.
+Require Import Coq.Lists.List.
 Require Import ExtLib.Programming.With.
 
 Record RTest : Set := mkRTest {

--- a/theories/Makefile
+++ b/theories/Makefile
@@ -28,6 +28,9 @@ uninstall: Makefile.coq
          rm -f $(shell coqc -where)/user-contrib/ExtLib/$$i; \
         done
 
+install-doc: Makefile.coq
+	$(MAKE) -f Makefile.coq html
+	$(MAKE) -f Makefile.coq install-doc
 
 test: coq Makefile.test.coq
 	$(MAKE) -f Makefile.test.coq


### PR DESCRIPTION
Fixes to build ext-lib under MacOS using Coq-8.4.

Please note that OPAM package here https://github.com/coq/opam-coq-archive/tree/master/released/packages/coq-ext-lib/coq-ext-lib.0.9.0 even though marked as compatible with Coq-8.4 fails to install. Once your source is fixed I will ping them to update the packet to use new version.