### PR TITLE
CoMonads

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -13,6 +13,7 @@ theories/Structures/Applicative.v
 theories/Structures/BinOps.v
 theories/Structures/CoFunctor.v
 theories/Structures/CoMonad.v
+theories/Structures/CoMonadLaws.v
 theories/Structures/EqDep.v
 theories/Structures/Foldable.v
 theories/Structures/FunctorLaws.v

--- a/theories/Data/Lazy.v
+++ b/theories/Data/Lazy.v
@@ -15,8 +15,8 @@ Definition _lazy {T : Type} (l : T) : Lazy T := fun _ => l.
 Definition force {T : Type} (l : Lazy T) : T := l tt.
 
 Global Instance CoMonad_Lazy : CoMonad Lazy :=
-{ coret := @force
-; cobind _A _B a b := fun x : unit => b a
+{ extract := @force
+; extend _A _B b a := fun x : unit => b a
 }.
 
 Global Instance Functor_Lazy : Functor Lazy :=

--- a/theories/Generic/Ind.v
+++ b/theories/Generic/Ind.v
@@ -65,7 +65,7 @@ Global Instance Data_nat : Data nat :=
     | inr (inr x) => match x with end
   end
 ; rec := fun c _ A z s d =>
-  coret ((fix recur (d : nat) {struct d} : c A :=
+  extract ((fix recur (d : nat) {struct d} : c A :=
     match d with
       | 0 => z
       | S n => s (recur n)
@@ -86,7 +86,7 @@ Global Instance Data_list {A} : Data (list A) :=
     | inr (inr x) => match x with end
   end
 ; rec := fun c _ T n co d =>
-  coret ((fix recur (ds : list A) {struct ds} : c T :=
+  extract ((fix recur (ds : list A) {struct ds} : c T :=
     match ds with
       | nil => n
       | d :: ds => co d (recur ds)
@@ -99,8 +99,8 @@ Require Import ExtLib.Data.Monads.IdentityMonad.
 Require Import ExtLib.Structures.Monads.
 
 Global Instance Comoand_Id : CoMonad id :=
-{ coret := fun _ x => x
-; cobind := fun _ _ f x => x f
+{ extract := fun _ x => x
+; extend := fun _ _ x f => x f
 }.
 
 (*

--- a/theories/Structures/CoMonad.v
+++ b/theories/Structures/CoMonad.v
@@ -2,6 +2,6 @@ Set Implicit Arguments.
 Set Strict Implicit.
 
 Class CoMonad (m : Type -> Type) : Type :=
-{ coret : forall {A}, m A -> A
-; cobind : forall {A B}, m A -> (m A -> B) -> m B
+{ extract : forall {A}, m A -> A
+; extend : forall {A B}, (m A -> B) -> m A -> m B
 }.

--- a/theories/Structures/CoMonadLaws.v
+++ b/theories/Structures/CoMonadLaws.v
@@ -1,0 +1,25 @@
+Require Import Coq.Program.Basics.
+Require Import ExtLib.Structures.CoMonad.
+
+Set Implicit Arguments.
+Set Strict Implicit.
+
+Local Open Scope program_scope.
+
+Section CoMonadLaws.
+  Variable m : Type -> Type.
+  Variable C : CoMonad m.
+
+  Class CoMonadLaws : Type :=
+    {
+      extend_extract: forall (A B:Type),
+        extend (B:=A) extract = id ;
+
+      extract_extend: forall (A B:Type) {f},
+          extract ∘ extend (A:=A) (B:=B) f = f;
+
+      extend_extend:forall (A B:Type) {f g},
+          extend (A:=B) (B:=A) f ∘ extend (A:=A) g = extend (f ∘ extend g)
+    }.
+
+End CoMonadLaws.


### PR DESCRIPTION
1. Renamed CoMonad functions `coret` and `cobind` to match names (`extract`, `extend`) and argument order used in Haskell and some literature. The additional reason for the change in the order of arguments is to make it easier to formulate comonad laws without using additional lambdas.

2. Added simple CoMonadLaws class.

Inspired by Haskell comonad library: https://github.com/ekmett/comonad

