### PR TITLE
Prepare for porting to lia

### DIFF
--- a/examples/ConsiderDemo.v
+++ b/examples/ConsiderDemo.v
@@ -4,7 +4,7 @@ Require Import ExtLib.Tactics.Consider.
 Require Import Coq.Bool.Bool.
 Require Import ExtLib.Data.Nat.
 
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 
 Set Implicit Arguments.
 Set Strict Implicit.

--- a/theories/Data/ListFirstnSkipn.v
+++ b/theories/Data/ListFirstnSkipn.v
@@ -1,5 +1,5 @@
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
 
 Lemma firstn_app_L : forall T n (a b : list T),
   n <= length a ->


### PR DESCRIPTION
This backward-compatible patch prepares ext-lib for
https://github.com/coq/coq/pull/7878