### PR TITLE
make state universe polymorphic.

### DIFF
--- a/theories/Data/Monads/StateMonad.v
+++ b/theories/Data/Monads/StateMonad.v
@@ -3,6 +3,8 @@ Require Import ExtLib.Structures.Monoid.
 
 Set Implicit Arguments.
 Set Strict Implicit.
+Set Primitive Projections.
+Set Universe Polymorphism.
 
 Section StateType.
   Variable S : Type.


### PR DESCRIPTION
This would close #48, this seems like a fairly large change, but given that template universe polymorphism is going to go away at some point, it might be worth doing it now.

- For consistency, we should probably make all the monads universe polymorphic...