### PR TITLE
Do not rely on `Refine Instance Mode`

### DIFF
--- a/theories/Data/Fin.v
+++ b/theories/Data/Fin.v
@@ -68,8 +68,8 @@ Fixpoint make (m n : nat) {struct m} : pf_lt n m -> fin m :=
 Notation "'##' n" := (@make _ n I) (at level 0).
 
 Global Instance Injective_FS {n : nat} (a b : fin n)
-  : Injective (FS a = FS b) :=
-{ result := a = b }.
+  : Injective (FS a = FS b).
+refine {| result := a = b |}.
 abstract (intro ; inversion H ; eapply inj_pair2 in H1 ; assumption).
 Defined.
 

--- a/theories/Data/List.v
+++ b/theories/Data/List.v
@@ -221,40 +221,46 @@ Section ListEq.
 
 End ListEq.
 
-Global Instance Injective_cons T (a : T) b c d : Injective (a :: b = c :: d) :=
-  { result := a = c /\ b = d }.
+Global Instance Injective_cons T (a : T) b c d : Injective (a :: b = c :: d).
+refine {| result := a = c /\ b = d |}.
 inversion 1; auto.
 Defined.
 
-Global Instance Injective_cons_nil T (a : T) b : Injective (a :: b = nil) :=
-  { result := False }.
+Global Instance Injective_cons_nil T (a : T) b : Injective (a :: b = nil).
+refine {| result := False |}.
 inversion 1; auto.
 Defined.
 
-Global Instance Injective_nil_cons T (a : T) b : Injective (nil = a :: b) :=
-  { result := False }.
+Global Instance Injective_nil_cons T (a : T) b : Injective (nil = a :: b).
+refine {| result := False |}.
 inversion 1; auto.
 Defined.
 
-Global Instance Injective_nil_nil T : Injective (nil = @nil T) :=
-  { result := True }.
+Global Instance Injective_nil_nil T : Injective (nil = @nil T).
+refine {| result := True |}.
 auto.
 Defined.
 
 Global Instance Injective_app_cons {T} (a : list T) b c d
-: Injective (a ++ b :: nil = (c ++ d :: nil)) :=
-  { result := a = c /\ b = d }.
-Proof. eapply app_inj_tail. Defined.
+: Injective (a ++ b :: nil = (c ++ d :: nil)).
+Proof.
+refine {| result := a = c /\ b = d |}.
+eapply app_inj_tail.
+Defined.
 
 Global Instance Injective_app_same_L {T} (a : list T) b c
-: Injective (b ++ a = b ++ c) :=
-  { result := a = c }.
-Proof. apply app_inv_head. Defined.
+: Injective (b ++ a = b ++ c).
+Proof.
+refine {| result := a = c |}.
+apply app_inv_head.
+Defined.
 
 Global Instance Injective_app_same_R {T} (a : list T) b c
-: Injective (a ++ b = c ++ b) :=
-{ result := a = c }.
-Proof. apply app_inv_tail. Defined.
+: Injective (a ++ b = c ++ b).
+Proof.
+refine {| result := a = c |}.
+apply app_inv_tail.
+Defined.
 
 
 Lemma eq_list_eq

--- a/theories/Data/Map/FMapPositive.v
+++ b/theories/Data/Map/FMapPositive.v
@@ -185,9 +185,9 @@ Section pmap.
       apply pmap_lookup_insert_None_neq; intuition].
   Qed.
 
-  Global Instance MapOk_pmap : MapOk (@eq _) Map_pmap :=
-  { mapsto := fun k v m => pmap_lookup k m = Some v }.
+  Global Instance MapOk_pmap : MapOk (@eq _) Map_pmap.
   Proof.
+  refine {| mapsto := fun k v m => pmap_lookup k m = Some v |}.
     { abstract (induction k; simpl; congruence). }
     { abstract (induction k; simpl; intros; forward). }
     { eauto using pmap_lookup_insert_eq. }

--- a/theories/Data/Member.v
+++ b/theories/Data/Member.v
@@ -106,9 +106,9 @@ Section member.
       | MN _ _ m => Some m
     end.
 
-  Instance Injective_MN x y ls m m' : Injective (@MN x y ls m = @MN x y ls m') :=
-  { result := m = m' }.
+  Instance Injective_MN x y ls m m' : Injective (@MN x y ls m = @MN x y ls m').
   Proof.
+  refine {| result := m = m' |}.
     intro.
     assert (get_next (MN y m) = get_next (MN y m')).
     { rewrite H. reflexivity. }

--- a/theories/Data/Nat.v
+++ b/theories/Data/Nat.v
@@ -101,10 +101,8 @@ Definition Monoid_nat_mult : Monoid nat :=
  ; monoid_unit := 1
  |}.
 
-Global Instance Injective_S (a b : nat) : Injective (S a = S b) :=
-{ result := a = b
-; injection := _
-}.
+Global Instance Injective_S (a b : nat) : Injective (S a = S b).
+refine {| result := a = b |}.
 abstract (inversion 1; auto).
 Defined.
 

--- a/theories/Data/Option.v
+++ b/theories/Data/Option.v
@@ -70,32 +70,32 @@ Section relation.
   Qed.
 
   Global Instance Injective_Roption_None
-  : Injective (Roption None None) :=
-    { result := True }.
+  : Injective (Roption None None).
+  refine {| result := True |}.
   auto.
   Defined.
 
   Global Instance Injective_Roption_None_Some a
-  : Injective (Roption None (Some a)) :=
-    { result := False }.
+  : Injective (Roption None (Some a)).
+  refine {| result := False |}.
   inversion 1.
   Defined.
 
   Global Instance Injective_Roption_Some_None a
-  : Injective (Roption (Some a) None) :=
-    { result := False }.
+  : Injective (Roption (Some a) None).
+  refine {| result := False |}.
   inversion 1.
   Defined.
 
   Global Instance Injective_Roption_Some_Some a b
-  : Injective (Roption (Some a) (Some b)) :=
-    { result := R a b }.
+  : Injective (Roption (Some a) (Some b)).
+  refine {| result := R a b |}.
   inversion 1. auto.
   Defined.
 
   Global Instance Injective_Proper_Roption_Some x
-  : Injective (Proper Roption (Some x)) :=
-    { result := R x x }.
+  : Injective (Proper Roption (Some x)).
+  refine {| result := R x x |}.
   abstract (inversion 1; assumption).
   Defined.
 

--- a/theories/Data/PPair.v
+++ b/theories/Data/PPair.v
@@ -55,9 +55,9 @@ Section Injective.
   Context {T : Type@{i}} {U : Type@{j}}.
 
   Global Instance Injective_pprod (a : T) (b : U) c d
-  : Injective (ppair a b = ppair c d) :=
-  { result := a = c /\ b = d }.
+  : Injective (ppair a b = ppair c d).
   Proof.
+  refine {| result := a = c /\ b = d |}.
     intros.
     change a with (pfst@{i j} {| pfst := a ; psnd := b |}).
     change b with (psnd@{i j} {| pfst := a ; psnd := b |}) at 2.

--- a/theories/Data/Pair.v
+++ b/theories/Data/Pair.v
@@ -25,8 +25,8 @@ Section Eqpair.
   : Transitive Eqpair.
   Proof. red. inversion 1; inversion 1; constructor; etransitivity; eauto. Qed.
 
-  Global Instance Injective_Eqpair a b c d : Injective (Eqpair (a,b) (c,d)) :=
-  { result := rT a c /\ rU b d }.
+  Global Instance Injective_Eqpair a b c d : Injective (Eqpair (a,b) (c,d)).
+  refine {| result := rT a c /\ rU b d |}.
   abstract (inversion 1; auto).
   Defined.
 End Eqpair.
@@ -118,6 +118,6 @@ Section PairEq.
   Qed.
 End PairEq.
 
-Global Instance Injective_pair T U (a :T) (b:U) c d : Injective ((a,b) = (c,d)) :=
-{| result := a = c /\ b = d |}.
+Global Instance Injective_pair T U (a :T) (b:U) c d : Injective ((a,b) = (c,d)).
+refine {| result := a = c /\ b = d |}.
 Proof. abstract (inversion 1; intuition). Defined.

--- a/theories/Data/SigT.v
+++ b/theories/Data/SigT.v
@@ -71,17 +71,17 @@ Section injective.
   Variable ED : EquivDec.EqDec _ (@eq T).
 
   Global Instance Injective_existT a b d
-    : Injective (existT F a b = existT F a d) | 1 :=
-  { result := b = d }.
+    : Injective (existT F a b = existT F a d) | 1.
+  refine {| result := b = d |}.
   abstract (eauto using inj_pair2).
   Defined.
 
   Global Instance Injective_existT_dif a b c d
-  : Injective (existT F a b = existT F c d) | 2 :=
-  { result := exists pf : c = a,
-    b = match pf in _ = t return F t with
-          | eq_refl => d
-        end }.
+  : Injective (existT F a b = existT F c d) | 2.
+  refine {| result := exists pf : c = a,
+            b = match pf in _ = t return F t with
+                  | eq_refl => d
+                end |}.
   abstract (inversion 1; subst; exists eq_refl; auto).
   Defined.
 End injective.

--- a/theories/Data/Sum.v
+++ b/theories/Data/Sum.v
@@ -80,18 +80,18 @@ Section SumEq.
   Qed.
 End SumEq.
 
-Global Instance Injective_inl T U a c : Injective (@inl T U a = inl c) :=
-{| result := a = c |}.
+Global Instance Injective_inl T U a c : Injective (@inl T U a = inl c).
+refine {| result := a = c |}.
 Proof. abstract (inversion 1; intuition). Defined.
 
-Global Instance Injective_inr T U a c : Injective (@inr T U a = inr c) :=
-{| result := a = c |}.
+Global Instance Injective_inr T U a c : Injective (@inr T U a = inr c).
+refine {| result := a = c |}.
 Proof. abstract (inversion 1; intuition). Defined.
 
-Global Instance Injective_inl_False T U a c : Injective (@inl T U a = inr c) :=
-{| result := False |}.
+Global Instance Injective_inl_False T U a c : Injective (@inl T U a = inr c).
+refine {| result := False |}.
 Proof. abstract (inversion 1; intuition). Defined.
 
-Global Instance Injective_inr_False T U a c : Injective (@inr T U a = inl c) :=
-{| result := False |}.
+Global Instance Injective_inr_False T U a c : Injective (@inr T U a = inl c).
+refine {| result := False |}.
 Proof. abstract (inversion 1; intuition). Defined.

--- a/theories/Programming/Le.v
+++ b/theories/Programming/Le.v
@@ -12,8 +12,9 @@ Instance lt_RelDec {T} {L:Lte T} {RD:RelDec lte} : RelDec lt :=
   { rel_dec x y := (rel_dec x y && negb (rel_dec y x))%bool }.
 
 Instance lt_RelDecCorrect {T} {L:Lte T} {RD:RelDec lte} {RDC:RelDec_Correct RD}
-  : RelDec_Correct lt_RelDec := { rel_dec_correct := _ }.
-Proof. intros ; constructor ; intros.
+  : RelDec_Correct lt_RelDec.
+Proof. constructor.
+  intros ; constructor ; intros.
   unfold rel_dec in H. simpl in H. apply andb_true_iff in H. destruct H.
     unfold lt. constructor. apply rel_dec_correct. auto.
     apply neg_rel_dec_correct. simpl in H0.

--- a/theories/Tactics/Reify.v
+++ b/theories/Tactics/Reify.v
@@ -22,10 +22,8 @@ Section ListReify.
   }.
 
   Global Instance  Reflect_cons a b (Ra : ClassReify f a) (Rb : ClassReify (map f) b) 
-  : ClassReify (map f) (a :: b) :=
-  { reify := cons (@reify _ _ _ _ Ra) (@reify _ _ _ _ Rb)
-  ; reify_sound := _
-  }.
+  : ClassReify (map f) (a :: b).
+  refine {| reify := cons (@reify _ _ _ _ Ra) (@reify _ _ _ _ Rb) |}.
   simpl; f_equal; eapply reify_sound.
   Defined.
 End ListReify.


### PR DESCRIPTION
This option is soon going to be turned off by default. See
https://github.com/coq/coq/pull/9270

This patch should be backward compatible.