### PR TITLE
Adding functions to go from lists to hlists and conversely.

### DIFF
--- a/theories/Data/HList.v
+++ b/theories/Data/HList.v
@@ -846,13 +846,13 @@ Section hlist_gen.
 
   (** This function is a generalisation of [hlist_gen] in which the function [f]
     takes the additional parameter [member a ls]. **)
-  Fixpoint hlist_gen_member ls : (forall a, member a ls -> F a) -> hlist F ls.
-  Proof.
-    intro fm. destruct ls.
-    - exact Hnil.
-    - refine (Hcons (fm _ (MZ _ _)) (hlist_gen_member _ _)).
-      clear - fm. intros a' M. exact (fm _ (MN _ M)).
-  Defined.
+  Fixpoint hlist_gen_member ls : (forall a, member a ls -> F a) -> hlist F ls :=
+    match ls as ls return ((forall a : A, member a ls -> F a) -> hlist F ls) with
+    | nil => fun _ => Hnil
+    | a :: ls' => fun fm =>
+        Hcons (fm a (MZ a ls'))
+          (hlist_gen_member (fun a' (M : member a' ls') => fm a' (MN a M)))
+    end.
 
   Lemma hlist_gen_member_hlist_gen : forall ls,
     hlist_gen_member (fun a _ => f a) = hlist_gen ls.
@@ -891,7 +891,8 @@ Proof.
 Qed.
 
 Global Instance Proper_hlist_gen : forall A F,
-  Proper (forall_relation (fun _ => eq) ==> forall_relation (fun _ => eq)) (@hlist_gen A F).
+  Proper (forall_relation (fun _ => eq) ==> forall_relation (fun _ => eq))
+         (@hlist_gen A F).
 Proof.
   repeat intro. apply hlist_gen_ext. auto.
 Qed.
@@ -905,8 +906,9 @@ Proof.
   induction ls; simpl; constructor; auto.
 Qed.
 
-Global Instance Proper_equiv_hlist_gen : forall A (F : A -> Type) ls R,
-  Proper (forall_relation R ==> equiv_hlist R (ls := ls)) (fun f => @hlist_gen A F f ls).
+Global Instance Proper_equiv_hlist_gen : forall A (F : A -> Type) R,
+  Proper (forall_relation R ==> forall_relation (@equiv_hlist _ _ R))
+         (@hlist_gen A F).
 Proof.
   repeat intro. apply equiv_hlist_gen. auto.
 Qed.

--- a/theories/Data/HList.v
+++ b/theories/Data/HList.v
@@ -847,10 +847,10 @@ Proof.
   induction m; simpl; auto.
 Qed.
 
-Lemma hlist_gen_ext : forall A F (f g : forall a : A, F a),
-  (forall x, f x = g x) ->
-  forall ls, hlist_gen f ls = hlist_gen g ls.
+Global Instance hlist_gen_ext : forall A F,
+  Proper (forall_relation (fun _ => eq) ==> forall_relation (fun _ => eq)) (@hlist_gen A F).
 Proof.
+  intros A F f1 f2 E1 ls.
   induction ls; simpl; f_equal; auto.
 Qed.
 
@@ -863,7 +863,7 @@ Proof.
   induction ls; simpl; constructor; auto.
 Qed.
 
-Fixpoint hlist_erase A B (ls : list A) (hs : hlist (fun _ => B) ls) : list B :=
+Fixpoint hlist_erase {A B} {ls : list A} (hs : hlist (fun _ => B) ls) : list B :=
   match hs with
   | Hnil => nil
   | Hcons _ _ x hs' => cons x (hlist_erase hs')

--- a/theories/Data/HList.v
+++ b/theories/Data/HList.v
@@ -8,7 +8,7 @@ Require Import ExtLib.Data.Member.
 Require Import ExtLib.Data.ListNth.
 Require Import ExtLib.Data.Option.
 Require Import ExtLib.Tactics.
-Require Import Morphisms.
+Require Import Coq.Classes.Morphisms.
 
 Set Implicit Arguments.
 Set Strict Implicit.
@@ -827,11 +827,26 @@ Qed.
 
 (** Linking Heterogeneous Lists and Lists **)
 
-Fixpoint hlist_gen {A} {F : A -> Type} (f : forall a, F a) (ls : list A) : hlist F ls :=
-  match ls with
-  | nil => Hnil
-  | cons x ls' => Hcons (f x) (hlist_gen f ls')
-  end.
+Section hlist_gen.
+  Variable A : Type.
+  Variable F : A -> Type.
+  Variable f : forall a, F a.
+
+  Fixpoint hlist_gen (ls : list A) : hlist F ls :=
+    match ls with
+    | nil => Hnil
+    | cons x ls' => Hcons (f x) (hlist_gen ls')
+    end.
+
+  Lemma hlist_get_hlist_gen : forall ls t (m : member t ls),
+    hlist_get m (hlist_gen ls) = f t.
+  Proof.
+    induction m; simpl; auto.
+  Qed.
+
+End hlist_gen.
+
+Arguments hlist_gen {A F} f ls.
 
 Lemma hlist_gen_hlist_map : forall A (F G : A -> Type) (ff : forall t, F t -> F t) f ls,
   hlist_map ff (hlist_gen f ls) = hlist_gen (fun a => ff _ (f a)) ls.
@@ -839,12 +854,6 @@ Proof.
   induction ls; simpl.
   - reflexivity.
   - rewrite IHls. reflexivity.
-Qed.
-
-Lemma hlist_get_hlist_gen : forall A F (f : forall a : A, F A) ls t (m : member t ls),
-  hlist_get m (hlist_gen f ls) = f t.
-Proof.
-  induction m; simpl; auto.
 Qed.
 
 Global Instance hlist_gen_ext : forall A F,

--- a/theories/Data/HList.v
+++ b/theories/Data/HList.v
@@ -860,6 +860,13 @@ Section hlist_gen.
     induction ls; simpl; f_equal; auto.
   Qed.
 
+  Lemma hlist_gen_member_ext : forall ls (f g : forall a, member a ls -> F a),
+    (forall x M, f x M = g x M) ->
+    hlist_gen_member f = hlist_gen_member g.
+  Proof.
+    intros. induction ls; simpl; f_equal; auto.
+  Qed.
+
 End hlist_gen.
 
 Arguments hlist_gen {A F} f ls.
@@ -876,11 +883,17 @@ Proof.
   intros. do 2 rewrite <- hlist_gen_member_hlist_gen. apply hlist_gen_member_hlist_map.
 Qed.
 
-Global Instance hlist_gen_ext : forall A F,
+Lemma hlist_gen_ext : forall A F (f g : forall a, F a),
+  (forall x, f x = g x) ->
+  forall ls : list A, hlist_gen f ls = hlist_gen g ls.
+Proof.
+  intros. do 2 rewrite <- hlist_gen_member_hlist_gen. apply hlist_gen_member_ext. auto.
+Qed.
+
+Global Instance Proper_hlist_gen : forall A F,
   Proper (forall_relation (fun _ => eq) ==> forall_relation (fun _ => eq)) (@hlist_gen A F).
 Proof.
-  intros A F f1 f2 E1 ls.
-  induction ls; simpl; f_equal; auto.
+  repeat intro. apply hlist_gen_ext. auto.
 Qed.
 
 Lemma equiv_hlist_gen : forall T (F : T -> Type) (f : forall t, F t) f'
@@ -890,6 +903,12 @@ Lemma equiv_hlist_gen : forall T (F : T -> Type) (f : forall t, F t) f'
     equiv_hlist R (hlist_gen f ls) (hlist_gen f' ls).
 Proof.
   induction ls; simpl; constructor; auto.
+Qed.
+
+Global Instance Proper_equiv_hlist_gen : forall A (F : A -> Type) ls R,
+  Proper (forall_relation R ==> equiv_hlist R (ls := ls)) (fun f => @hlist_gen A F f ls).
+Proof.
+  repeat intro. apply equiv_hlist_gen. auto.
 Qed.
 
 Fixpoint hlist_erase {A B} {ls : list A} (hs : hlist (fun _ => B) ls) : list B :=

--- a/theories/Data/HList.v
+++ b/theories/Data/HList.v
@@ -924,6 +924,21 @@ Proof.
 Qed.
 
 
+(** Linking Heterogeneous Lists and Predicates **)
+
+Section hlist_Forall.
+  Variable A : Type.
+  Variable P : A -> Prop.
+
+  Fixpoint hlist_Forall ls (hs : hlist P ls) : Forall P ls :=
+    match hs with
+    | Hnil => Forall_nil _
+    | Hcons _ _ H hs' => Forall_cons _ H (hlist_Forall hs')
+    end.
+
+End hlist_Forall.
+
+
 (** Heterogeneous Relations **)
 Section hlist_rel.
   Variable A : Type.

--- a/theories/Data/HList.v
+++ b/theories/Data/HList.v
@@ -823,6 +823,58 @@ Proof.
   - constructor; eauto.
 Qed.
 
+
+(** Links Heterogeneous Lists and Lists **)
+
+Fixpoint hlist_gen A (F : A -> Type) (f : forall a, F a) (ls : list A) : hlist F ls :=
+  match ls with
+  | nil => Hnil
+  | cons x ls' => Hcons (f x) (hlist_gen F f ls')
+  end.
+
+Lemma hlist_gen_hlist_map : forall A (F G : A -> Type) ff f ls,
+  hlist_map ff (hlist_gen F f ls) = hlist_gen G (fun a => ff _ (f a)) ls.
+Proof.
+  induction ls; simpl.
+  - reflexivity.
+  - rewrite IHls. reflexivity.
+Qed.
+
+Lemma hlist_get_hlist_gen : forall A F f ls (t : A) m,
+  hlist_get m (hlist_gen F f ls) = f t.
+Proof.
+  induction m; simpl; auto.
+Qed.
+
+Lemma hlist_gen_ext : forall A F f g,
+  (forall x, f x = g x) ->
+  forall ls : list A, hlist_gen F f ls = hlist_gen F g ls.
+Proof.
+  induction ls; simpl; f_equal; auto.
+Qed.
+
+Lemma equiv_hlist_gen : forall T (F : T -> Type) (f : forall t, F t) f'
+    (R : forall t, F t -> F t -> Prop),
+  (forall t, R t (f t) (f' t)) ->
+  forall ls,
+    equiv_hlist R (hlist_gen F f ls) (hlist_gen F f' ls).
+Proof.
+  induction ls; simpl; constructor; auto.
+Qed.
+
+Fixpoint hlist_erase A B (ls : list A) (hs : hlist (fun _ => B) ls) :=
+  match hs with
+  | Hnil => nil
+  | Hcons _ _ x hs' => cons x (hlist_erase hs')
+  end.
+
+Lemma hlist_erase_hlist_gen : forall A B ls (f : A -> B),
+  hlist_erase (hlist_gen (fun _ => B) f ls) = map f ls.
+Proof.
+  induction ls; simpl; intros; f_equal; auto.
+Qed.
+
+
 (** Heterogeneous Relations **)
 Section hlist_rel.
   Variable A : Type.


### PR DESCRIPTION
I didn’t find functions to go from `hlist`s to `list`s and conversely, so I created these. I tried to be consistent with the general style of the library.