### PR TITLE
Adding a way to convert [member]s into [In]s.

### DIFF
--- a/theories/Data/Member.v
+++ b/theories/Data/Member.v
@@ -132,4 +132,9 @@ Section member.
         eapply IHm in H. rewrite H. reflexivity. } }
   Qed.
 
+  Lemma member_In : forall ls (t : T), member t ls -> List.In t ls.
+  Proof.
+    induction 1; simpl; auto.
+  Qed.
+
 End member.


### PR DESCRIPTION
In the previous PR, we had this discussion that the parameter of `hlist_gen` should take either a `member` or a `In` as argument. I chose `member` as one can convert it into an `In` (whilst the convert doesn’t hold). I however didn’t find this lemma in the development. Here it is.