### PR TITLE
Implicit arguments for mkOptionT, mkEitherT, mkIdentT

### DIFF
--- a/theories/Data/Monads/EitherMonad.v
+++ b/theories/Data/Monads/EitherMonad.v
@@ -104,3 +104,6 @@ Section except.
   }.
 
 End except.
+
+Arguments mkEitherT {T} {m} {A} (_).
+Arguments unEitherT {T} {m} {A} (_).

--- a/theories/Data/Monads/IdentityMonad.v
+++ b/theories/Data/Monads/IdentityMonad.v
@@ -12,3 +12,6 @@ Section Ident.
   }.
 
 End Ident.
+
+Arguments mkIdent {A} (_).
+Arguments unIdent {A} (_).

--- a/theories/Data/Monads/OptionMonad.v
+++ b/theories/Data/Monads/OptionMonad.v
@@ -99,3 +99,6 @@ Section Trans.
   }.
 
 End Trans.
+
+Arguments mkOptionT {m} {a} (_).
+Arguments unOptionT {m} {a} (_).


### PR DESCRIPTION
Related to #58 (for mkStateT)

I wonder they should really be maximally inserted...