### PR TITLE
Fix w.r.t. coq/coq#10441.

### DIFF
--- a/theories/Core/Type.v
+++ b/theories/Core/Type.v
@@ -22,6 +22,7 @@ Polymorphic Definition type_libniz@{t} (T : Type@{t}) : type@{t} T :=
 
 Existing Class proper.
 
+#[universes(polymorphic)]
 Section type.
   Polymorphic Context {T : Type}.
   Polymorphic Variable tT : type T.

--- a/theories/Data/List.v
+++ b/theories/Data/List.v
@@ -134,6 +134,7 @@ Require Import ExtLib.Structures.Functor.
 Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.Applicative.
 
+#[universes(polymorphic)]
 Section traversable.
   Polymorphic Context {F : Type -> Type}.
   Polymorphic Context {Applicative_F : Applicative F}.

--- a/theories/Data/POption.v
+++ b/theories/Data/POption.v
@@ -4,6 +4,7 @@ Require Import ExtLib.Tactics.Injection.
 
 Set Printing Universes.
 
+#[universes(polymorphic)]
 Section poption.
   Polymorphic Universe i.
   Polymorphic Variable T : Type@{i}.
@@ -56,6 +57,7 @@ End poption.
 Arguments pSome {_} _.
 Arguments pNone {_}.
 
+#[universes(polymorphic)]
 Section poption_map.
   Polymorphic Universes i j.
   Polymorphic Context {T : Type@{i}} {U : Type@{j}}.

--- a/theories/Data/PPair.v
+++ b/theories/Data/PPair.v
@@ -20,7 +20,6 @@ Arguments ppair {_ _} _ _.
 Arguments pfst {_ _} _.
 Arguments psnd {_ _} _.
 
-Section equality.
   Polymorphic Lemma eq_pair_rw
   : forall T U (a b : T) (c d : U) (pf : (ppair a c) = (ppair b d)),
     exists (pf' : a = b) (pf'' : c = d),
@@ -48,7 +47,6 @@ Section equality.
     generalize dependent (ppair a c).
     intros; subst. reflexivity.
   Defined.
-End equality.
 
 Section Injective.
   Polymorphic Universes i j.

--- a/theories/Data/PreFun.v
+++ b/theories/Data/PreFun.v
@@ -8,6 +8,7 @@ Set Strict Implicit.
 
 Polymorphic Definition Fun@{d c} (A : Type@{d}) (B : Type@{c}) := A -> B.
 
+#[universes(polymorphic)]
 Section type.
   Polymorphic Variables (T : Type) (U : Type) (tT : type T) (tU : type U).
 

--- a/theories/Programming/Show.v
+++ b/theories/Programming/Show.v
@@ -75,6 +75,7 @@ Polymorphic Definition indent (indent : showM) (v : showM) : showM :=
          then monoid_plus mon (inj a) (indent _ inj mon)
          else inj a) mon.
 
+#[universes(polymorphic)]
 Section sepBy.
   Import ShowNotation.
   Local Open Scope show_scope.
@@ -93,6 +94,7 @@ Section sepBy.
     end.
 End sepBy.
 
+#[universes(polymorphic)]
 Section sepBy_f.
   Import ShowNotation.
   Local Open Scope show_scope.
@@ -116,6 +118,7 @@ End sepBy_f.
 Polymorphic Definition wrap (before after : showM) (x : showM) : showM :=
   cat before (cat x after).
 
+#[universes(polymorphic)]
 Section sum_Show.
   Import ShowNotation.
   Local Open Scope show_scope.
@@ -138,6 +141,7 @@ Section sum_Show.
 
 End sum_Show.
 
+#[universes(polymorphic)]
 Section foldable_Show.
   Polymorphic Context {A:Type} {B:Type} {F : Foldable B A} {BS : Show A}.
 
@@ -192,15 +196,19 @@ Section hiding_notation.
       | Zneg p => "-"%char << show p
       end.
 
-  Section pair_Show.
-    Polymorphic Definition pair_Show@{a m}
-                {A : Type@{a}} {B : Type@{a}} {AS:Show A} {BS:Show B}
-    : Show (A*B) :=
-      fun p =>
-        let (a,b) := p in
-        "("%char << show a << ","%char << show b << ")"%char.
-  End pair_Show.
 End hiding_notation.
+
+#[universes(polymorphic)]
+Section pair_Show.
+  Import ShowNotation.
+  Local Open Scope show_scope.
+  Polymorphic Definition pair_Show@{a m}
+              {A : Type@{a}} {B : Type@{a}} {AS:Show A} {BS:Show B}
+  : Show (A*B) :=
+    fun p =>
+      let (a,b) := p in
+      "("%char << show a << ","%char << show b << ")"%char.
+End pair_Show.
 
 
 

--- a/theories/Structures/Applicative.v
+++ b/theories/Structures/Applicative.v
@@ -17,6 +17,7 @@ Module ApplicativeNotation.
 End ApplicativeNotation.
 Import ApplicativeNotation.
 
+#[universes(polymorphic)]
 Section applicative.
   Polymorphic Definition liftA@{d c} {T : Type@{d} -> Type@{c}} {AT:Applicative@{d c} T} {A B : Type@{d}} (f:A -> B) (aT:T A) : T B := pure f <*> aT.
   Polymorphic Definition liftA2@{d c} {T : Type@{d} -> Type@{c}} {AT:Applicative@{d c} T} {A B C : Type@{d}} (f:A -> B -> C) (aT:T A) (bT:T B) : T C := liftA f aT <*> bT.

--- a/theories/Structures/CoFunctor.v
+++ b/theories/Structures/CoFunctor.v
@@ -3,6 +3,7 @@ Require Import ExtLib.Core.Any.
 Set Implicit Arguments.
 Set Strict Implicit.
 
+#[universes(polymorphic)]
 Section functor.
 
   Polymorphic Class CoFunctor@{d c} (F : Type@{d} -> Type@{c}) : Type :=

--- a/theories/Structures/FunctorLaws.v
+++ b/theories/Structures/FunctorLaws.v
@@ -8,6 +8,7 @@ Require Import ExtLib.Structures.Functor.
 Set Implicit Arguments.
 Set Strict Implicit.
 
+#[universes(polymorphic)]
 Section laws.
 
   Polymorphic Class FunctorLaws@{t u X}

--- a/theories/Structures/Monad.v
+++ b/theories/Structures/Monad.v
@@ -25,6 +25,7 @@ Global Polymorphic Instance PMonad_Monad m (M : Monad m) : PMonad m :=
 ; pbind := fun _ _ _ c f => bind c f
 }.
 
+#[universes(polymorphic)]
 Section monadic.
 
   Polymorphic Definition liftM@{d c}
@@ -52,6 +53,10 @@ Section monadic.
               {M : Monad m}
               {A B : Type@{d}} (fM:m (A -> B)) (aM:m A) : m B :=
     bind fM (fun f => liftM f aM).
+
+End monadic.
+
+Section monadic.
 
   (* Left-to-right composition of Kleisli arrows. *)
   Definition mcompose@{c d}

--- a/theories/Structures/Monoid.v
+++ b/theories/Structures/Monoid.v
@@ -4,6 +4,7 @@ Require Import ExtLib.Structures.BinOps.
 Set Implicit Arguments.
 Set Maximal Implicit Insertion.
 
+#[universes(polymorphic)]
 Section Monoid.
   Polymorphic Variable S : Type.
 


### PR DESCRIPTION
Not backwards compatible, but could be made so with a bit of work. Questions about this below.

I have trouble understanding the design choices underlying ext-lib, maybe the changes of this PR are not the right ones.

- First, it seems that the `Polymorphic` qualifier is used a lot, where the polymorphic universe option could be set instead. Is that a conscious design choice, or is it a remnant of the time when universe polymorphism was still very experimental? This forces me to put polymorphic attributes on sections.
- Some sections are willingly mixing polymorphic and monomorphic data, seemingly. Is that on purpose? I had to extrude them.
