### PR TITLE
Fix inconsistent notation levels associativity

### DIFF
--- a/theories/Structures/Applicative.v
+++ b/theories/Structures/Applicative.v
@@ -13,7 +13,7 @@ Polymorphic Class Applicative@{d c} (T : Type@{d} -> Type@{c}) :=
 }.
 
 Module ApplicativeNotation.
-  Notation "f <*> x" := (ap f x) (at level 51, left associativity).
+  Notation "f <*> x" := (ap f x) (at level 52, left associativity).
 End ApplicativeNotation.
 Import ApplicativeNotation.
 

--- a/theories/Structures/Functor.v
+++ b/theories/Structures/Functor.v
@@ -26,5 +26,5 @@ Polymorphic Definition PFunctor_From_Functor@{d c p}
 Global Existing Instance PFunctor_From_Functor.
 
 Module FunctorNotation.
-  Notation "f <$> x" := (@pfmap _ _ _ _ _ f x) (at level 51, left associativity).
+  Notation "f <$> x" := (@pfmap _ _ _ _ _ f x) (at level 52, left associativity).
 End FunctorNotation.

--- a/theories/Structures/Monad.v
+++ b/theories/Structures/Monad.v
@@ -69,17 +69,17 @@ Module MonadNotation.
 
   Notation "c >>= f" := (@pbind _ _ _ _ _ c f) (at level 50, left associativity) : monad_scope.
   Notation "f =<< c" := (@pbind _ _ _ _ _ c f) (at level 51, right associativity) : monad_scope.
-  Notation "f >=> g" := (@mcompose _ _ _ _ _ f g) (at level 60, right associativity) : monad_scope.
+  Notation "f >=> g" := (@mcompose _ _ _ _ _ f g) (at level 61, right associativity) : monad_scope.
 
   Notation "x <- c1 ;; c2" := (@pbind _ _ _ _ _ c1 (fun x => c2))
-    (at level 60, c1 at next level, right associativity) : monad_scope.
+    (at level 61, c1 at next level, right associativity) : monad_scope.
 
   Notation "e1 ;; e2" := (_ <- e1%monad ;; e2%monad)%monad
-    (at level 60, right associativity) : monad_scope.
+    (at level 61, right associativity) : monad_scope.
 
   Notation "' pat <- c1 ;; c2" :=
     (@pbind _ _ _ _ _ c1 (fun x => match x with pat => c2 end))
-    (at level 60, pat pattern, c1 at next level, right associativity) : monad_scope.
+    (at level 61, pat pattern, c1 at next level, right associativity) : monad_scope.
 
 End MonadNotation.
 


### PR DESCRIPTION
Declaring two notations with different associativities but the same
precedence level leads to a conflict. Instead we establish the
convention that even precedence levels are for left-associative
notations, and odd precedence levels are for right-associative notations.

Fixes #66.