### PR TITLE
Makefile: improve clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ examples: theories
 	$(MAKE) -C examples
 
 clean:
-	$(MAKE) -f Makefile.coq clean
+	if [ -e Makefile.coq ] ; then $(MAKE) -f Makefile.coq cleanall ; fi
 	$(MAKE) -C examples clean
-	@ rm Makefile.coq
+	@rm -f Makefile.coq Makefile.coq.conf
 
 uninstall:
 	$(MAKE) -f Makefile.coq uninstall

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,9 +1,9 @@
 coq: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
-clean: Makefile.coq
-	$(MAKE) -f Makefile.coq clean
-	rm Makefile.coq
+clean:
+	if [ -e Makefile.coq ] ; then $(MAKE) -f Makefile.coq cleanall ; fi
+	rm -f Makefile.coq Makefile.coq.conf
 
 Makefile.coq: Makefile _CoqProject
 	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq


### PR DESCRIPTION
- `cleanall` also cleans `.aux` files
- do nothing if no makefile exists
- ~~`$(RM)` is `rm -f` (I admit I don't actually see a reason to prefer this macro over the expanded form...)~~