### PR TITLE
Replace section annotations with global Set Universe Polymorphism

### DIFF
--- a/theories/Core/Type.v
+++ b/theories/Core/Type.v
@@ -1,43 +1,45 @@
 Require Import Coq.Setoids.Setoid.
 Require Import ExtLib.Structures.Proper.
 
+Set Universe Polymorphism.
+
 (** Types are defined by their equivalence relations
  ** Proper elements are the elements for which the equivalence
  ** relation is reflexive.
  **)
-Polymorphic Class type@{t} (T : Type@{t}) : Type :=
+Class type@{t} (T : Type@{t}) : Type :=
 { equal : T -> T -> Prop
 ; proper : T -> Prop
 }.
 
-Polymorphic Definition type_from_equal@{t} {T : Type@{t}} (r : T -> T -> Prop) : type@{t} T :=
+Definition type_from_equal@{t} {T : Type@{t}} (r : T -> T -> Prop) : type@{t} T :=
 {| equal := r
  ; proper := fun x => r x x
  |}.
 
-Polymorphic Definition type_libniz@{t} (T : Type@{t}) : type@{t} T :=
+Definition type_libniz@{t} (T : Type@{t}) : type@{t} T :=
 {| equal := @eq T
  ; proper := fun _ => True
  |}.
 
 Existing Class proper.
 
-#[universes(polymorphic)]
 Section type.
-  Polymorphic Context {T : Type}.
-  Polymorphic Variable tT : type T.
+  Universe u.
+  Context {T : Type@{u}}.
+  Variable tT : type T.
 (*
   Global Instance Proper_type : Proper T :=
   { proper := fun x => equal x x }.
 *)
-  Polymorphic Class typeOk :=
+  Class typeOk@{} :=
   { only_proper : forall x y, equal x y -> proper x /\ proper y
   ; equiv_prefl :> PReflexive proper equal
   ; equiv_sym :> Symmetric equal
   ; equiv_trans :> Transitive equal
   }.
 
-  Global Polymorphic Instance proper_left :
+  Global Instance proper_left@{} :
     typeOk ->
     forall x y : T, equal x y -> proper x.
   Proof.
@@ -46,7 +48,7 @@ Section type.
     | H : equal _ _ |- _ => eapply only_proper in H
     end; intuition.
   Qed.
-  Global Polymorphic Instance proper_right :
+  Global Instance proper_right@{} :
     typeOk ->
     forall x y : T, equal x y -> proper y.
   Proof.
@@ -59,40 +61,40 @@ Section type.
 End type.
 
 
-Polymorphic Definition type1@{d r z} (F : Type@{d} -> Type@{r}) : Type@{z} :=
+Definition type1@{d r z} (F : Type@{d} -> Type@{r}) : Type@{z} :=
   forall {T:Type@{d}}, type@{d} T -> type@{r} (F T).
 
-Polymorphic Definition type2@{t u v z} (F : Type@{t} -> Type@{u} -> Type@{v}) : Type@{z} :=
+Definition type2@{t u v z} (F : Type@{t} -> Type@{u} -> Type@{v}) : Type@{z} :=
   forall {T:Type@{t}}, type T -> forall {U:Type@{u}}, type U -> type (F T U).
 
-Polymorphic Definition type3@{t u v w z} (F : Type@{t} -> Type@{u} -> Type@{v} -> Type@{w}) : Type@{z} :=
+Definition type3@{t u v w z} (F : Type@{t} -> Type@{u} -> Type@{v} -> Type@{w}) : Type@{z} :=
   forall {T:Type@{t}}, type T -> forall {U:Type@{u}}, type U -> forall {V:Type@{w}}, type V ->  type (F T U V).
 
-Polymorphic Definition typeOk1@{d r z} (F : Type@{d} -> Type@{r}) (tF : type1@{d r z} F) : Type@{z} :=
+Definition typeOk1@{d r z} (F : Type@{d} -> Type@{r}) (tF : type1@{d r z} F) : Type@{z} :=
   forall (T : Type@{d}) tT, @typeOk T tT -> typeOk (tF _ tT).
 
-Polymorphic Definition typeOk2@{t u v z}
+Definition typeOk2@{t u v z}
             (F : Type@{t} -> Type@{u} -> Type@{v}) (tF : type2@{t u v z} F)
 : Type@{z} :=
   forall (T : Type@{t}) (tT : type@{t} T), @typeOk@{t} T tT -> typeOk1@{u v z} _ (tF _ tT).
 
-Polymorphic Definition typeOk3@{t u v w z} F (tF : type3 F) : Type@{z} :=
+Definition typeOk3@{t u v w z} F (tF : type3 F) : Type@{z} :=
   forall (T : Type@{t}) (tT : type T), @typeOk@{t} T tT -> typeOk2@{u v w z} _ (tF _ tT).
 
 Existing Class type1.
 Existing Class type2.
 Existing Class type3.
 
-Global Polymorphic Instance type_type1 F (tF : type1 F) T (tT : type T) : type (F T) :=
+Global Instance type_type1 F (tF : type1 F) T (tT : type T) : type (F T) :=
   tF _ tT.
 
-Global Polymorphic Instance type1_type2 F (tF : type2 F) T (tT : type T) : type1 (F T) :=
+Global Instance type1_type2 F (tF : type2 F) T (tT : type T) : type1 (F T) :=
   tF _ tT.
 
-Global Polymorphic Instance type2_type3 F (tF : type3 F) T (tT : type T) : type2 (F T) :=
+Global Instance type2_type3 F (tF : type3 F) T (tT : type T) : type2 (F T) :=
   tF _ tT.
 
-Polymorphic Class Oktype T : Type :=
+Class Oktype T : Type :=
 { the_type :> type T
 ; the_proof :> typeOk the_type
 }.
@@ -110,19 +112,20 @@ Global Instance typeOk2_typeOk3 F (tF : type3 F) T (tT : type T) : type2 (F T) :
 
 
 Section typeOk_from_equal.
-  Context {T} (r : relation T).
+  Universe u.
+  Context {T : Type@{u}} (r : relation T).
   Hypothesis p : forall x y, r x y -> r x x /\ r y y.
   Hypothesis sym : Symmetric r.
   Hypothesis trans : Transitive r.
 
-  Theorem typeOk_from_equal  : typeOk (type_from_equal r).
+  Theorem typeOk_from_equal@{} : typeOk (type_from_equal r).
   Proof.
     constructor; auto.
     { simpl. red. auto. }
   Qed.
 End typeOk_from_equal.
 
-Theorem typeOk_libniz T : typeOk (type_libniz T).
+Theorem typeOk_libniz@{u} (T : Type@{u}) : typeOk (type_libniz T).
 Proof.
   constructor; unfold equal, type_libniz; auto with typeclass_instances.
   { split; exact I. }

--- a/theories/Data/List.v
+++ b/theories/Data/List.v
@@ -10,23 +10,25 @@ Require Import ExtLib.Tactics.Injection.
 
 Set Implicit Arguments.
 Set Strict Implicit.
+Set Universe Polymorphism.
 
 Section type.
-  Variable T : Type.
+  Universe u.
+  Variable T : Type@{u}.
   Context {type_T : type T}.
 
-  Inductive list_eq : list T -> list T -> Prop :=
+  Inductive list_eq@{} : list T -> list T -> Prop :=
   | nil_eq : list_eq nil nil
   | cons_eq : forall x xs y ys, equal x y -> list_eq xs ys -> list_eq (x :: xs) (y :: ys).
 
-  Instance type_list : type (list T) :=
+  Instance type_list@{} : type@{u} (list T) :=
   { equal := list_eq
   ; proper := Forall proper
   }.
 
   Context {typeOk_T : typeOk type_T}.
 
-  Instance typeOk_list : typeOk type_list.
+  Instance typeOk_list@{} : typeOk type_list.
   Proof.
     constructor.
     { intros. induction H.
@@ -47,10 +49,11 @@ Section type.
 End type.
 
 Section EqDec.
-  Variable T : Type.
+  Universe u.
+  Variable T : Type@{u}.
   Variable EqDec_T : EquivDec.EqDec _ (@eq T).
 
-  Global Instance EqDec_list : EquivDec.EqDec _ (@eq (list T)).
+  Global Instance EqDec_list@{} : EquivDec.EqDec _ (@eq (list T)).
   Proof.
     red. unfold Equivalence.equiv, RelationClasses.complement.
     intros.
@@ -60,8 +63,8 @@ Section EqDec.
 End EqDec.
 
 (* Specialized induction rules *)
-Lemma list_ind_singleton
-: forall {T : Type} (P : list T -> Prop)
+Lemma list_ind_singleton@{u}
+: forall {T : Type@{u}} (P : list T -> Prop)
          (Hnil : P nil)
          (Hsingle : forall t, P (t :: nil))
          (Hcons : forall t u us, P (u :: us) -> P (t :: u :: us)),
@@ -71,8 +74,8 @@ Proof.
   destruct ls. eauto. eauto.
 Qed.
 
-Lemma list_rev_ind
-  : forall T (P : list T -> Prop),
+Lemma list_rev_ind@{u}
+  : forall (T : Type@{u}) (P : list T -> Prop),
     P nil ->
     (forall l ls, P ls -> P (ls ++ l :: nil)) ->
     forall ls, P ls.
@@ -84,17 +87,18 @@ Proof.
 Qed.
 
 Section AllB.
-  Variable T : Type.
+  Universe u.
+  Variable T : Type@{u}.
   Variable p : T -> bool.
 
-  Fixpoint allb (ls : list T) : bool :=
+  Fixpoint allb@{} (ls : list T) : bool :=
     match ls with
       | nil => true
       | l :: ls =>
         if p l then allb ls else false
     end.
 
-  Fixpoint anyb (ls : list T) : bool :=
+  Fixpoint anyb@{} (ls : list T) : bool :=
     match ls with
       | nil => false
       | l :: ls =>
@@ -102,8 +106,8 @@ Section AllB.
     end.
 End AllB.
 
-Lemma Forall_map
-: forall T U (f : T -> U) P ls,
+Lemma Forall_map@{uT uU}
+: forall (T : Type@{uT}) (U : Type@{uU}) (f : T -> U) P ls,
     Forall P (List.map f ls) <-> Forall (fun x => P (f x)) ls.
 Proof.
   induction ls; simpl.
@@ -112,21 +116,21 @@ Proof.
     apply IHls. auto. apply IHls. auto. }
 Qed.
 
-Lemma Forall_cons_iff : forall (T : Type) (P : T -> Prop) a b,
+Lemma Forall_cons_iff@{u} : forall (T : Type@{u}) (P : T -> Prop) a b,
     Forall P (a :: b) <-> (P a /\ Forall P b).
 Proof. clear. split.
        inversion 1; auto.
        destruct 1; constructor; auto.
 Qed.
 
-Lemma Forall_nil_iff : forall (T : Type) (P : T -> Prop),
+Lemma Forall_nil_iff@{u} : forall (T : Type@{u}) (P : T -> Prop),
     Forall P nil <-> True.
 Proof.
   clear. split; auto.
 Qed.
 
 
-Global Instance Foldable_list {T} : Foldable (list T) T :=
+Global Instance Foldable_list@{u} {T : Type@{u}} : Foldable (list T) T :=
   fun _ f x ls => fold_right f x ls.
 
 Require Import ExtLib.Structures.Traversable.
@@ -134,36 +138,36 @@ Require Import ExtLib.Structures.Functor.
 Require Import ExtLib.Structures.Monad.
 Require Import ExtLib.Structures.Applicative.
 
-#[universes(polymorphic)]
 Section traversable.
-  Polymorphic Context {F : Type -> Type}.
-  Polymorphic Context {Applicative_F : Applicative F}.
-  Polymorphic Context {A B : Type}.
-  Polymorphic Variable f : A -> F B.
+  Universe u v vF.
+  Context {F : Type@{v} -> Type@{vF}}.
+  Context {Applicative_F : Applicative F}.
+  Context {A : Type@{u}} {B : Type@{v}}.
+  Variable f : A -> F B.
 
-  Polymorphic Fixpoint mapT_list (ls : list A) : F (list B) :=
+  Fixpoint mapT_list@{} (ls : list A) : F (list B) :=
     match ls with
       | nil => pure nil
       | l :: ls => ap (ap (pure (@cons B)) (f l)) (mapT_list ls)
     end.
 End traversable.
 
-Global Instance Traversable_list : Traversable list :=
+Global Instance Traversable_list@{} : Traversable list :=
 { mapT := @mapT_list }.
 
-Global Instance Monad_list : Monad list :=
+Monomorphic Universe listU.
+
+Global Instance Monad_list@{} : Monad@{listU listU} list :=
 { ret  := fun _ x => x :: nil
 ; bind := fun _ _ x f =>
   List.fold_right (fun x acc => f x ++ acc) nil x
 }.
 
-
-
 Section list.
-  Inductive R_list_len {T} : list T -> list T -> Prop :=
+  Inductive R_list_len@{u} {T : Type@{u}} : list T -> list T -> Prop :=
   | R_l_len : forall n m, length n < length m -> R_list_len n m.
 
-  Theorem wf_R_list_len T : well_founded (@R_list_len T).
+  Theorem wf_R_list_len@{u} (T : Type@{u}) : well_founded (@R_list_len T).
   Proof.
     constructor. intros.
     refine (@Fix _ _ Nat.wf_R_lt (fun n : nat => forall ls : list T, n = length ls -> Acc R_list_len ls)
@@ -183,16 +187,17 @@ Section list.
   Defined.
 End list.
 
-Definition Monoid_list_app {T} : Monoid (list T) :=
+Definition Monoid_list_app@{u v} {T : Type@{u}} : Monoid@{v} (list T) :=
 {| monoid_plus := @List.app _
  ; monoid_unit := @nil _
  |}.
 
 Section ListEq.
-  Variable T : Type.
+  Universe u.
+  Variable T : Type@{u}.
   Variable EDT : RelDec (@eq T).
 
-  Fixpoint list_eqb (ls rs : list T) : bool :=
+  Fixpoint list_eqb@{} (ls rs : list T) : bool :=
     match ls , rs with
       | nil , nil => true
       | cons l ls , cons r rs =>
@@ -201,62 +206,57 @@ Section ListEq.
     end.
 
   (** Specialization for equality **)
-  Global Instance RelDec_eq_list : RelDec (@eq (list T)) :=
+  Global Instance RelDec_eq_list@{} : RelDec (@eq (list T)) :=
   { rel_dec := list_eqb }.
 
   Variable EDCT : RelDec_Correct EDT.
 
-  Global Instance RelDec_Correct_eq_list : RelDec_Correct RelDec_eq_list.
+  Global Instance RelDec_Correct_eq_list@{v} : RelDec_Correct RelDec_eq_list.
   Proof.
     constructor; induction x; destruct y; split; simpl in *; intros;
-      repeat match goal with
-               | [ H : context [ rel_dec ?X ?Y ] |- _ ] =>
-                 consider (rel_dec X Y); intros; subst
-               | [ |- context [ rel_dec ?X ?Y ] ] =>
-                 consider (rel_dec X Y); intros; subst
-             end; try solve [ auto | exfalso; clear - H; inversion H ].
-    - f_equal. eapply IHx. eapply H0.
-    - inversion H. subst. eapply IHx. reflexivity.
-    - inversion H. exfalso. eapply H0. assumption.
+      try reflexivity + discriminate.
+    - destruct (_ : Reflect (rel_dec a t) _ _); try discriminate.
+      replace y with x by (apply IHx; auto); subst; auto.
+    - inversion H; subst. rewrite (rel_dec_eq_true _) by auto. apply IHx; auto.
   Qed.
 
 End ListEq.
 
-Global Instance Injective_cons T (a : T) b c d : Injective (a :: b = c :: d).
+Global Instance Injective_cons@{u} (T : Type@{u}) (a : T) b c d : Injective (a :: b = c :: d).
 refine {| result := a = c /\ b = d |}.
 inversion 1; auto.
 Defined.
 
-Global Instance Injective_cons_nil T (a : T) b : Injective (a :: b = nil).
+Global Instance Injective_cons_nil@{u} (T : Type@{u}) (a : T) b : Injective (a :: b = nil).
 refine {| result := False |}.
 inversion 1; auto.
 Defined.
 
-Global Instance Injective_nil_cons T (a : T) b : Injective (nil = a :: b).
+Global Instance Injective_nil_cons@{u} (T : Type@{u}) (a : T) b : Injective (nil = a :: b).
 refine {| result := False |}.
 inversion 1; auto.
 Defined.
 
-Global Instance Injective_nil_nil T : Injective (nil = @nil T).
+Global Instance Injective_nil_nil@{u} (T : Type@{u}) : Injective (nil = @nil T).
 refine {| result := True |}.
 auto.
 Defined.
 
-Global Instance Injective_app_cons {T} (a : list T) b c d
+Global Instance Injective_app_cons@{u} {T : Type@{u}} (a : list T) b c d
 : Injective (a ++ b :: nil = (c ++ d :: nil)).
 Proof.
 refine {| result := a = c /\ b = d |}.
 eapply app_inj_tail.
 Defined.
 
-Global Instance Injective_app_same_L {T} (a : list T) b c
+Global Instance Injective_app_same_L@{u} {T : Type@{u}} (a : list T) b c
 : Injective (b ++ a = b ++ c).
 Proof.
 refine {| result := a = c |}.
 apply app_inv_head.
 Defined.
 
-Global Instance Injective_app_same_R {T} (a : list T) b c
+Global Instance Injective_app_same_R@{u} {T : Type@{u}} (a : list T) b c
 : Injective (a ++ b = c ++ b).
 Proof.
 refine {| result := a = c |}.
@@ -264,8 +264,8 @@ apply app_inv_tail.
 Defined.
 
 
-Lemma eq_list_eq
-: forall T (a b : T) (pf : a = b) (F : _ -> Type) val,
+Lemma eq_list_eq@{u v}
+: forall (T : Type@{u}) (a b : T) (pf : a = b) (F : T -> Type@{v}) val,
     match pf in _ = x return list (F x) with
       | eq_refl => val
     end = map (fun val => match pf in _ = x return F x with

--- a/theories/Data/POption.v
+++ b/theories/Data/POption.v
@@ -2,18 +2,18 @@ Require Import ExtLib.Structures.Functor.
 Require Import ExtLib.Structures.Applicative.
 Require Import ExtLib.Tactics.Injection.
 
+Set Universe Polymorphism.
 Set Printing Universes.
 
-#[universes(polymorphic)]
 Section poption.
-  Polymorphic Universe i.
-  Polymorphic Variable T : Type@{i}.
+  Universe i.
+  Variable T : Type@{i}.
 
-  Polymorphic Inductive poption : Type@{i} :=
+  Inductive poption : Type@{i} :=
   | pSome : T -> poption
   | pNone.
 
-  Global Polymorphic Instance Injective_pSome a b
+  Global Instance Injective_pSome@{} a b
   : Injective (pSome a = pSome b) :=
   { result := a = b
   ; injection := fun pf =>
@@ -26,12 +26,12 @@ Section poption.
                    | eq_refl => eq_refl
                    end }.
 
-  Global Polymorphic Instance Injective_pSome_pNone a
+  Global Instance Injective_pSome_pNone a
   : Injective (pSome a = pNone) :=
   { result := False
   ; injection := fun pf =>
                    match pf in _ = X
-                         return match X with
+                         return match X return Prop with
                                 | pSome y => True
                                 | _ => False
                                 end
@@ -39,12 +39,12 @@ Section poption.
                    | eq_refl => I
                    end }.
 
-  Global Polymorphic Instance Injective_pNone_pSome a
+  Global Instance Injective_pNone_pSome@{} a
   : Injective (pNone = pSome a) :=
   { result := False
   ; injection := fun pf =>
                    match pf in _ = X
-                         return match X with
+                         return match X return Prop with
                                 | pNone => True
                                 | _ => False
                                 end
@@ -57,19 +57,18 @@ End poption.
 Arguments pSome {_} _.
 Arguments pNone {_}.
 
-#[universes(polymorphic)]
 Section poption_map.
-  Polymorphic Universes i j.
-  Polymorphic Context {T : Type@{i}} {U : Type@{j}}.
-  Polymorphic Variable f : T -> U.
+  Universes i j.
+  Context {T : Type@{i}} {U : Type@{j}}.
+  Variable f : T -> U.
 
-  Polymorphic Definition fmap_poption (x : poption@{i} T) : poption@{j} U :=
+  Definition fmap_poption@{} (x : poption@{i} T) : poption@{j} U :=
     match x with
     | pNone => pNone@{j}
     | pSome x => pSome@{j} (f x)
     end.
 
-  Polymorphic Definition ap_poption
+  Definition ap_poption@{}
               (f : poption@{i} (T -> U)) (x : poption@{i} T)
   : poption@{j} U :=
     match f , x with
@@ -79,12 +78,11 @@ Section poption_map.
 
 End poption_map.
 
-Polymorphic Definition Functor_poption@{i} : Functor@{i i} poption@{i} :=
+Definition Functor_poption@{i} : Functor@{i i} poption@{i} :=
 {| fmap := @fmap_poption@{i i} |}.
 Existing Instance Functor_poption.
 
-
-Polymorphic Definition Applicative_poption@{i} : Applicative@{i i} poption@{i} :=
+Definition Applicative_poption@{i} : Applicative@{i i} poption@{i} :=
 {| pure := @pSome@{i}
  ; ap   := @ap_poption |}.
 Existing Instance Applicative_poption.

--- a/theories/Data/PreFun.v
+++ b/theories/Data/PreFun.v
@@ -5,21 +5,22 @@ Require Import ExtLib.Core.Type.
 
 Set Implicit Arguments.
 Set Strict Implicit.
+Set Universe Polymorphism.
 
-Polymorphic Definition Fun@{d c} (A : Type@{d}) (B : Type@{c}) := A -> B.
+Definition Fun@{d c} (A : Type@{d}) (B : Type@{c}) := A -> B.
 
-#[universes(polymorphic)]
 Section type.
-  Polymorphic Variables (T : Type) (U : Type) (tT : type T) (tU : type U).
+  Universe uT uU.
+  Variables (T : Type@{uT}) (U : Type@{uU}) (tT : type T) (tU : type U).
 
-  Global Polymorphic Instance type_Fun  : type (T -> U) :=
+  Global Instance type_Fun@{uU'} : type@{uU'} (T -> U) :=
   { equal := fun f g => respectful equal equal f g
   ; proper := fun x => respectful equal equal x x
   }.
 
-  Polymorphic Variables (tOk : typeOk tT) (uOk : typeOk tU).
+  Variables (tOk : typeOk tT) (uOk : typeOk tU).
 
-  Global Polymorphic Instance typeOk_Fun : typeOk type_Fun.
+  Global Instance typeOk_Fun@{uU'} : typeOk@{uU'} type_Fun.
   Proof.
     constructor.
     { unfold equiv. simpl. unfold respectful.
@@ -42,28 +43,28 @@ Section type.
       apply tOk. }
   Qed.
 
-  Global Polymorphic Instance proper_app : forall (f : T -> U) (a : T),
-    proper f -> proper a -> proper (f a).
+  Global Instance proper_app@{uU'} : forall (f : T -> U) (a : T),
+    proper@{uU'} f -> proper a -> proper (f a).
   Proof.
     simpl; intros. red in H.
     eapply proper_left; eauto.
     eapply H. eapply preflexive. eapply equiv_prefl; auto. auto.
   Qed.
 
-  Polymorphic Theorem proper_fun : forall (f : T -> U),
+  Theorem proper_fun@{uU'} : forall (f : T -> U),
     (forall x y, equal x y -> equal (f x) (f y)) ->
-    proper f.
+    proper@{uU'} f.
   Proof.
     intros. do 3 red. eauto.
   Qed.
 
-  Polymorphic Theorem equal_fun : forall (f g : T -> U),
+  Theorem equal_fun@{uU'} : forall (f g : T -> U),
     (forall x y, equal x y -> equal (f x) (g y)) ->
-    equal f g.
+    equal@{uU'} f g.
   Proof. intros. do 3 red. apply H. Qed.
 
-  Polymorphic Theorem equal_app : forall (f g : T -> U) (x y : T),
-    equal f g -> equal x y ->
+  Theorem equal_app@{uU'} : forall (f g : T -> U) (x y : T),
+    equal@{uU'} f g -> equal x y ->
     equal (f x) (g y).
   Proof.
     clear. intros. do 3 red in H. auto.
@@ -71,5 +72,6 @@ Section type.
 
 End type.
 
-Polymorphic Definition compose {A:Type} {B:Type} {C : Type} (g : B -> C) (f : A -> B) : A -> C :=
+Definition compose@{uA uB uC} {A:Type@{uA}} {B:Type@{uB}} {C : Type@{uC}}
+    (g : B -> C) (f : A -> B) : A -> C :=
   fun x => g (f x).

--- a/theories/Programming/Show.v
+++ b/theories/Programming/Show.v
@@ -14,15 +14,16 @@ Require Import ExtLib.Core.RelDec.
 
 Set Implicit Arguments.
 Set Strict Implicit.
+Set Universe Polymorphism.
 
 Set Printing Universes.
 
-Universe Ushow.
+Monomorphic Universe Ushow.
 
-Polymorphic Definition showM@{T} : Type@{Ushow} :=
+Definition showM@{T} : Type@{Ushow} :=
   forall m : Type@{T}, Injection ascii m -> Monoid m -> m.
 
-Polymorphic Class ShowScheme@{t} (T : Type@{t}) : Type :=
+Class ShowScheme@{t} (T : Type@{t}) : Type :=
 { show_mon : Monoid@{t} T
 ; show_inj : Injection ascii T
 }.
@@ -37,23 +38,23 @@ Global Instance ShowScheme_string_compose : ShowScheme (string -> string) :=
 ; show_inj := String
 }.
 
-Polymorphic Definition runShow {T} {M : ShowScheme T} (m : showM) : T :=
+Definition runShow {T} {M : ShowScheme T} (m : showM) : T :=
   m _ show_inj show_mon.
 
-Polymorphic Class Show@{t m} (T : Type@{t}) : Type :=
+Class Show@{t m} (T : Type@{t}) : Type :=
   show : T -> showM@{m}.
 
-Polymorphic Definition to_string {T} {M : Show T} (v : T) : string :=
+Definition to_string {T} {M : Show T} (v : T) : string :=
   runShow (show v) ""%string.
 
-Polymorphic Definition empty : showM :=
+Definition empty : showM :=
   fun _ _ m => monoid_unit m.
-Polymorphic Definition cat (a b : showM) : showM :=
+Definition cat (a b : showM) : showM :=
   fun _ i m => monoid_plus m (a _ i m) (b _ i m).
-Global Polymorphic Instance Injection_ascii_showM : Injection ascii showM :=
+Global Instance Injection_ascii_showM : Injection ascii showM :=
   fun v => fun _ i _ => i v.
 
-Polymorphic Fixpoint show_exact (s : string) : showM :=
+Fixpoint show_exact (s : string) : showM :=
   match s with
     | EmptyString => empty
     | String a s' => cat (inject a) (show_exact s')
@@ -68,19 +69,18 @@ Module ShowNotation.
   Coercion _inject_char : ascii >-> showM.
 End ShowNotation.
 
-Polymorphic Definition indent (indent : showM) (v : showM) : showM :=
+Definition indent (indent : showM) (v : showM) : showM :=
   let nl := Ascii.ascii_of_nat 10 in
     fun _ inj mon =>
       v _ (fun a => if eq_dec a nl
          then monoid_plus mon (inj a) (indent _ inj mon)
          else inj a) mon.
 
-#[universes(polymorphic)]
 Section sepBy.
   Import ShowNotation.
   Local Open Scope show_scope.
 
-  Polymorphic Definition sepBy {T : Type}
+  Definition sepBy {T : Type}
               {F : Foldable T showM} (sep : showM) (ls : T) : showM :=
     match
       fold (fun s acc =>
@@ -94,15 +94,14 @@ Section sepBy.
     end.
 End sepBy.
 
-#[universes(polymorphic)]
 Section sepBy_f.
   Import ShowNotation.
   Local Open Scope show_scope.
-  Polymorphic Variables (T : Type) (E : Type).
-  Polymorphic Context {F : Foldable T E}.
-  Polymorphic Variable (f : E -> showM).
+  Variables (T : Type) (E : Type).
+  Context {F : Foldable T E}.
+  Variable (f : E -> showM).
 
-  Polymorphic Definition sepBy_f (sep : showM) (ls : T) : showM :=
+  Definition sepBy_f (sep : showM) (ls : T) : showM :=
     match
       fold (fun s acc =>
         match acc with
@@ -115,15 +114,14 @@ Section sepBy_f.
     end.
 End sepBy_f.
 
-Polymorphic Definition wrap (before after : showM) (x : showM) : showM :=
+Definition wrap (before after : showM) (x : showM) : showM :=
   cat before (cat x after).
 
-#[universes(polymorphic)]
 Section sum_Show.
   Import ShowNotation.
   Local Open Scope show_scope.
 
-  Polymorphic Definition sum_Show@{a m}
+  Definition sum_Show@{a m}
               {A : Type@{a}} {B : Type@{a}} {AS:Show@{a m} A} {BS:Show@{a m} B}
   : Show@{a m} (A+B) :=
     fun s =>
@@ -141,16 +139,15 @@ Section sum_Show.
 
 End sum_Show.
 
-#[universes(polymorphic)]
 Section foldable_Show.
-  Polymorphic Context {A:Type} {B:Type} {F : Foldable B A} {BS : Show A}.
+  Context {A:Type} {B:Type} {F : Foldable B A} {BS : Show A}.
 
-  Global Polymorphic  Instance foldable_Show : Show B :=
+  Global Instance foldable_Show : Show B :=
     { show s := sepBy_f show (show_exact ", "%string) s }.
 
 End foldable_Show.
 
-Polymorphic Fixpoint iter_show (ss : list showM) : showM :=
+Fixpoint iter_show (ss : list showM) : showM :=
   match ss with
     | nil => empty
     | cons s ss => cat s (iter_show ss)
@@ -198,19 +195,16 @@ Section hiding_notation.
 
 End hiding_notation.
 
-#[universes(polymorphic)]
 Section pair_Show.
   Import ShowNotation.
   Local Open Scope show_scope.
-  Polymorphic Definition pair_Show@{a m}
+  Definition pair_Show@{a m t}
               {A : Type@{a}} {B : Type@{a}} {AS:Show A} {BS:Show B}
-  : Show (A*B) :=
+  : Show@{_ t} (A*B) :=
     fun p =>
       let (a,b) := p in
       "("%char << show a << ","%char << show b << ")"%char.
 End pair_Show.
-
-
 
 (*
 Examples:

--- a/theories/Structures/Applicative.v
+++ b/theories/Structures/Applicative.v
@@ -1,13 +1,14 @@
 Set Implicit Arguments.
 Set Maximal Implicit Insertion.
+Set Universe Polymorphism.
 
-Polymorphic Class PApplicative@{d c p} (T : Type@{d} -> Type@{c}) :=
+Class PApplicative@{d c p} (T : Type@{d} -> Type@{c}) :=
 { AppP : Type@{d} -> Type@{p}
 ; ppure : forall {A : Type@{d}} {P : AppP A}, A -> T A
 ; pap : forall {A B : Type@{d}} {P : AppP B}, T (A -> B) -> T A -> T B
 }.
 
-Polymorphic Class Applicative@{d c} (T : Type@{d} -> Type@{c}) :=
+Class Applicative@{d c} (T : Type@{d} -> Type@{c}) :=
 { pure : forall {A : Type@{d}}, A -> T A
 ; ap : forall {A B : Type@{d}}, T (A -> B) -> T A -> T B
 }.
@@ -17,8 +18,7 @@ Module ApplicativeNotation.
 End ApplicativeNotation.
 Import ApplicativeNotation.
 
-#[universes(polymorphic)]
 Section applicative.
-  Polymorphic Definition liftA@{d c} {T : Type@{d} -> Type@{c}} {AT:Applicative@{d c} T} {A B : Type@{d}} (f:A -> B) (aT:T A) : T B := pure f <*> aT.
-  Polymorphic Definition liftA2@{d c} {T : Type@{d} -> Type@{c}} {AT:Applicative@{d c} T} {A B C : Type@{d}} (f:A -> B -> C) (aT:T A) (bT:T B) : T C := liftA f aT <*> bT.
+  Definition liftA@{d c} {T : Type@{d} -> Type@{c}} {AT:Applicative@{d c} T} {A B : Type@{d}} (f:A -> B) (aT:T A) : T B := pure f <*> aT.
+  Definition liftA2@{d c} {T : Type@{d} -> Type@{c}} {AT:Applicative@{d c} T} {A B C : Type@{d}} (f:A -> B -> C) (aT:T A) (bT:T B) : T C := liftA f aT <*> bT.
 End applicative.

--- a/theories/Structures/CoFunctor.v
+++ b/theories/Structures/CoFunctor.v
@@ -2,14 +2,14 @@ Require Import ExtLib.Core.Any.
 
 Set Implicit Arguments.
 Set Strict Implicit.
+Set Universe Polymorphism.
 
-#[universes(polymorphic)]
 Section functor.
 
-  Polymorphic Class CoFunctor@{d c} (F : Type@{d} -> Type@{c}) : Type :=
+  Class CoFunctor@{d c} (F : Type@{d} -> Type@{c}) : Type :=
   { cofmap : forall {A B : Type@{d}}, (B -> A) -> F A -> F B }.
 
-  Polymorphic Class CoPFunctor@{d c p} (F : Type@{d} -> Type@{c}) : Type :=
+  Class CoPFunctor@{d c p} (F : Type@{d} -> Type@{c}) : Type :=
   { CoFunP : Type@{d} -> Type@{p}
   ; copfmap : forall {A B : Type@{d}} {P : CoFunP B}, (B -> A) -> F A -> F B
   }.
@@ -17,9 +17,8 @@ Section functor.
   Existing Class CoFunP.
   Hint Extern 0 (@CoFunP _ _ _) => progress (simpl CoFunP) : typeclass_instances.
 
-  Polymorphic Definition CoPFunctor_From_CoFunctor@{d c p} (F : Type@{d} -> Type@{c}) (F_ : CoFunctor@{d c} F) : CoPFunctor@{d c p} F :=
+  Global Instance CoPFunctor_From_CoFunctor@{d c p} (F : Type@{d} -> Type@{c}) (F_ : CoFunctor@{d c} F) : CoPFunctor@{d c p} F :=
   {| CoFunP := Any@{p}
    ; copfmap := fun _ _ _ f x => cofmap f x
    |}.
-  Global Existing Instance CoPFunctor_From_CoFunctor.
 End functor.

--- a/theories/Structures/FunctorLaws.v
+++ b/theories/Structures/FunctorLaws.v
@@ -7,11 +7,11 @@ Require Import ExtLib.Structures.Functor.
 
 Set Implicit Arguments.
 Set Strict Implicit.
+Set Universe Polymorphism.
 
-#[universes(polymorphic)]
 Section laws.
 
-  Polymorphic Class FunctorLaws@{t u X}
+  Class FunctorLaws@{t u X}
               (F : Type@{t} -> Type@{u})
               (Functor_F : Functor F)
               (Feq : type1@{t u X} F)

--- a/theories/Structures/Monad.v
+++ b/theories/Structures/Monad.v
@@ -4,13 +4,14 @@ Require Import ExtLib.Structures.Applicative.
 
 Set Implicit Arguments.
 Set Strict Implicit.
+Set Universe Polymorphism.
 
-Polymorphic Class Monad@{d c} (m : Type@{d} -> Type@{c}) : Type :=
+Class Monad@{d c} (m : Type@{d} -> Type@{c}) : Type :=
 { ret : forall {t : Type@{d}}, t -> m t
 ; bind : forall {t u : Type@{d}}, m t -> (t -> m u) -> m u
 }.
 
-Polymorphic Class PMonad@{d c p} (m : Type@{d} -> Type@{c}) : Type :=
+Class PMonad@{d c p} (m : Type@{d} -> Type@{c}) : Type :=
 { MonP : Type@{d} -> Type@{p}
 ; pret : forall {t : Type@{d}} {Pt : MonP t}, t -> m t
 ; pbind : forall {t u : Type@{d}} {Pu : MonP u}, m t -> (t -> m u) -> m u
@@ -19,44 +20,39 @@ Polymorphic Class PMonad@{d c p} (m : Type@{d} -> Type@{c}) : Type :=
 Existing Class MonP.
 Hint Extern 0 (@MonP _ _ _) => progress (simpl MonP) : typeclass_instances.
 
-Global Polymorphic Instance PMonad_Monad m (M : Monad m) : PMonad m :=
+Global Instance PMonad_Monad@{d c p} (m : Type@{d} -> Type@{c}) (M : Monad m) : PMonad@{d c p} m :=
 { MonP := Any
 ; pret := fun _ _ x => ret x
 ; pbind := fun _ _ _ c f => bind c f
 }.
 
-#[universes(polymorphic)]
 Section monadic.
 
-  Polymorphic Definition liftM@{d c}
+  Definition liftM@{d c}
               {m : Type@{d} -> Type@{c}}
               {M : Monad m}
               {T U : Type@{d}} (f : T -> U) : m T -> m U :=
     fun x => bind x (fun x => ret (f x)).
 
-  Polymorphic Definition liftM2@{d c}
+  Definition liftM2@{d c}
               {m : Type@{d} -> Type@{c}}
               {M : Monad m}
               {T U V : Type@{d}} (f : T -> U -> V) : m T -> m U -> m V :=
     Eval cbv beta iota zeta delta [ liftM ] in
       fun x y => bind x (fun x => liftM (f x) y).
 
-  Polymorphic Definition liftM3@{d c}
+  Definition liftM3@{d c}
               {m : Type@{d} -> Type@{c}}
               {M : Monad m}
               {T U V W : Type@{d}} (f : T -> U -> V -> W) : m T -> m U -> m V -> m W :=
     Eval cbv beta iota zeta delta [ liftM2 ] in
       fun x y z => bind x (fun x => liftM2 (f x) y z).
 
-  Polymorphic Definition apM@{d c}
+  Definition apM@{d c}
               {m : Type@{d} -> Type@{c}}
               {M : Monad m}
               {A B : Type@{d}} (fM:m (A -> B)) (aM:m A) : m B :=
     bind fM (fun f => liftM f aM).
-
-End monadic.
-
-Section monadic.
 
   (* Left-to-right composition of Kleisli arrows. *)
   Definition mcompose@{c d}
@@ -88,23 +84,33 @@ Module MonadNotation.
 
 End MonadNotation.
 
-Polymorphic Instance Functor_Monad {m} {M:Monad m} : Functor m :=
+Section Instances.
+
+Universe d c.
+Context (m : Type@{d} -> Type@{c}) {M : Monad m}.
+
+Global Instance Functor_Monad@{} : Functor m :=
 { fmap := @liftM _ _ }.
 
-Polymorphic Instance PFunctor_PMonad {m} {M : PMonad m} : PFunctor m :=
+Global Instance Applicative_Monad@{} : Applicative m :=
+{ pure := @ret _ _
+; ap := @apM _ _
+}.
+
+Universe p.
+Context {PM : PMonad@{d c p} m}.
+
+Global Instance PFunctor_PMonad@{} : PFunctor m :=
 { FunP := MonP
 ; pfmap := fun _ _ _ f a =>
   pbind a (fun x => pret (f x))
 }.
 
-Polymorphic Instance PApplicative_PMonad {m} {M:PMonad m} : PApplicative m :=
+Global Instance PApplicative_PMonad@{} : PApplicative m :=
 { AppP := MonP
 ; ppure := fun _ _ x => pret x
 ; pap := fun _ _ _ f x =>
   pbind f (fun f => pbind x (fun x => pret (f x)))
 }.
 
-Polymorphic Instance Applicative_Monad {m} {M:Monad m} : Applicative m :=
-{ pure := @ret _ _
-; ap := @apM _ _
-}.
+End Instances.

--- a/theories/Structures/Monoid.v
+++ b/theories/Structures/Monoid.v
@@ -3,19 +3,20 @@ Require Import ExtLib.Structures.BinOps.
 
 Set Implicit Arguments.
 Set Maximal Implicit Insertion.
+Set Universe Polymorphism.
 
-#[universes(polymorphic)]
 Section Monoid.
-  Polymorphic Variable S : Type.
+  Universe u.
+  Variable S : Type@{u}.
 
-  Polymorphic Record Monoid : Type :=
+  Record Monoid@{} : Type :=
   { monoid_plus : S -> S -> S
   ; monoid_unit : S
   }.
 
-  Polymorphic Context {Type_S : type S}.
+  Context {Type_S : type S}.
 
-  Polymorphic Class MonoidLaws (M : Monoid) : Type :=
+  Class MonoidLaws@{} (M : Monoid) : Type :=
   { monoid_assoc :> Associative M.(monoid_plus) equal
   ; monoid_lunit :> LeftUnit M.(monoid_plus) M.(monoid_unit) equal
   ; monoid_runit :> RightUnit M.(monoid_plus) M.(monoid_unit) equal


### PR DESCRIPTION
Follow up from the discussion at the end of #65 

Also fixes coq/opam-coq-archive#939

The main point is to make this build again on 8.9, but I also did some clean up in the affected files (I only changed files touched by #65 but the same thing could be done throughout).

- Removed `Polymorphic` keywords, which is now implicit. Furthermore `Universe` has different semantics when this is on.

- Explicit universe quantification. The proof `RelDec_Correct_eq_list` and a few definitions (`Injective` instances in `POption`) needed a little fixing to avoid introducing spurious universes. The only exception is `Show`, which I'd rather rewrite or deprecate altogether (in favor of a more structured representation than strings), so I only did the minimum.